### PR TITLE
Feature/add initial menu editing

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,18 @@ This is not the best code in the world. This is just a tribute. I wanted to see 
 The code is under the MIT license.
 
 # Tiny TinaCMS Test
-This little setup is a minimal way to test features from TinaCMS without mixing in other complex build and content delivery systems. The purpose is as follows.
+This little setup is a minimal way to test features from `TinaCMS` without mixing in other complex build and content delivery systems. The purpose is as follows.
 * Be small
 * Be clean
 * Require little resources
 * Enable experimenting with `TinaCMS`
+
+## Not so Tiny TinaCMS Test
+This project has seen some extreme feature creap in order to try out `TinaCMS` feature in an orderly fashion. The current additional goals are as follows.
+* Use generic backend data suppliers in entire system
+* Use injection via ex. contexts and providers in order to separate the blog from the CMS
+* Enable building a CMS free javascript bundle
+* Include basic and advanced blog feature in order to use as much of `TinaCMS` as possible
 
 ## Running
 The result will be hosted on `localhost:5000` by default.

--- a/src/components/cms/entry-selectors.tsx
+++ b/src/components/cms/entry-selectors.tsx
@@ -1,6 +1,5 @@
 import * as React from "react";
 import {
-    useCMS,
     useScreenPlugin,
 } from "tinacms";
 import {useHistory} from "react-router-dom";

--- a/src/components/cms/index.ts
+++ b/src/components/cms/index.ts
@@ -1,4 +1,6 @@
 export * from "./post-provider";
 export * from "./page-provider";
+export * from "./menu-provider";
 export * from "./entry-selection";
 export * from "./entry-selectors";
+export * from "./utilities";

--- a/src/components/cms/menu-provider.tsx
+++ b/src/components/cms/menu-provider.tsx
@@ -137,7 +137,9 @@ export const TinaMenuProvider: React.SFC<MenuProviderProps> = ({menuId, children
         items: menu.entries.map((entry, index) => ({
             label: entry.name,
             key: entry.name + "-" + index,
-            onClick: () => entry.link && history.push(entry.link),
+            onClick: entry.link ? (
+                () => entry.link && history.push(entry.link)
+            ) : undefined,
         })),
     } : {
         items: []

--- a/src/components/cms/menu-provider.tsx
+++ b/src/components/cms/menu-provider.tsx
@@ -1,0 +1,150 @@
+import * as React from "react";
+import {useHistory} from "react-router-dom";
+import {
+    FormOptions,
+    useForm,
+    usePlugin,
+} from "tinacms";
+
+import {
+    Entry,
+    Menu,
+    MenuEntry,
+} from "../../modules/datastore";
+
+import {
+    MenuContext,
+    MenuData,
+} from "../../contexts";
+
+import {useMenus} from "../../modules/cms";
+
+export function useMenuForm(
+    menuId: string,
+    loadInitialValues: () => Promise<Entry & Menu>,
+    onSubmit: (menuProps: Partial<Entry & Menu>) => Promise<void>,
+    label: string = "Menu content",
+): Entry & Menu {
+    const formOptions: FormOptions<Entry & Menu> = {
+        id: "__menu:" + menuId,
+        label: label,
+        fields: [
+            {
+                label: "Name",
+                name: "name",
+                component: "text",
+            },
+            {
+                label: "Link",
+                name: "link",
+                component: "text",
+            },
+            {
+                label: "Menu items",
+                name: "entries",
+                component: "group-list",
+                description: "A list of menu items",
+                itemProps: (item) => ({
+                    key: item.key,
+                    label: item.name,
+                }),
+                defaultItem: () => ({
+                    name: "New item",
+                    key: "__item:" + Date.now(),
+                }),
+                fields: [
+                    {
+                        label: "Name",
+                        name: "name",
+                        component: "text",
+                    },
+                    {
+                        label: "Link",
+                        name: "link",
+                        component: "text",
+                    },
+                ],
+            },
+            {
+                label: "Tags",
+                name: "tags",
+                component: "group-list",
+                description: "A list of menu tags",
+                itemProps: item => ({
+                    key: item._key,
+                    label: item.name,
+                }),
+                defaultItem: () => ({
+                    name: "New tag",
+                    key: "__tag:" + Date.now(),
+                }),
+                fields: [
+                    {
+                        label: "Name",
+                        name: "name",
+                        component: "text",
+                    },
+                ],
+            }
+        ],
+        loadInitialValues: loadInitialValues,
+        onSubmit: onSubmit
+    };
+    const [menu, menuForm] = useForm<Entry & Menu>(formOptions);
+    usePlugin(menuForm);
+    return menu;
+}
+
+export type MenuProviderProps = {
+    menuId?: string;
+    children: any;
+};
+
+export const TinaMenuProvider: React.SFC<MenuProviderProps> = ({menuId, children}) => {
+    const history = useHistory();
+    const menusApi = useMenus();
+    const menu = useMenuForm(
+        menuId || "__no_menu",
+        async () => {
+            const selectedMenu = menuId !== undefined ? await menusApi.first({
+                type: "property",
+                propertyId: "name" as "name",
+                criteria: menuId,
+            }) : undefined;
+            return selectedMenu || {
+                id: "",
+                name: menuId || "",
+                entries: [],
+                tags: [],
+            };
+        },
+        async (updatedMenu) => {
+            if (updatedMenu.id) {
+                menusApi.update({
+                    id: updatedMenu.id,
+                    ...updatedMenu
+                });
+            } else {
+                menusApi.add({
+                    name: updatedMenu.name || "",
+                    entries: updatedMenu.entries || [],
+                    tags: updatedMenu.tags || [],
+                });
+            }
+        }
+    );
+    const menuData: MenuData | null = menu && menu.entries ? {
+        items: menu.entries.map((entry, index) => ({
+            label: entry.name,
+            key: entry.name + "-" + index,
+            onClick: () => entry.link && history.push(entry.link),
+        })),
+    } : {
+        items: []
+    };
+    return (
+        <MenuContext.Provider value={menuData}>
+            {React.Children.toArray(children)}
+        </MenuContext.Provider>
+    );
+}

--- a/src/components/cms/page-provider.tsx
+++ b/src/components/cms/page-provider.tsx
@@ -31,14 +31,14 @@ export const TinaPageProvider: React.SFC<{pageId: string, children: any}> = ({pa
 
     if (post === undefined) return null;
 
-    const postData: ContentData = {
-        type: ContentType.Post,
+    const pageData: ContentData = {
+        type: ContentType.Page,
         title: post.title,
         content: post.content,
         headerImage: post.imageUrl,
-    }
+    };
     return (
-        <ContentContext.Provider value={postData}>
+        <ContentContext.Provider value={pageData}>
             {React.Children.toArray(children)}
         </ContentContext.Provider>
     )

--- a/src/components/menu.tsx
+++ b/src/components/menu.tsx
@@ -31,7 +31,7 @@ export const Menu: React.SFC<MenuProps> = function ({items}: MenuProps) {
     return (
         <MenuWrapper>
             {items.map(item => (
-                <MenuItem key={item.key}>
+                <MenuItem key={item.key} onClick={item.onClick}>
                     {item.label}
                 </MenuItem>
             ))}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -15,17 +15,17 @@ import {
     LocalStorageStore,
     Post,
     Author,
+    Menu,
 } from "./modules/datastore";
 import {
-    MenuContext,
     ContentContext,
 } from "./contexts";
 import {
     TinaPostProvider,
     TinaPageProvider,
+    TinaMenuProvider,
 } from "./components/cms";
 import {
-    mockMenuData,
     mockPagesData,
     mockListingsData,
 } from "./modules/mock-data";
@@ -33,15 +33,17 @@ import {
     HashRouter as Router,
     Route,
     Switch,
+    useRouteMatch,
 } from "react-router-dom";
 
 
 const CMSProvider: React.FunctionComponent<{init: () => TinaCMS, children}> = (props) => {
     const cms = useMemo(props.init, []);
+    const routeMatch = useRouteMatch<{menuId: string}>("/menu/:menuId");
 
     return (
-        <MenuContext.Provider value={mockMenuData}>
-            <TinaProvider cms={cms}>
+        <TinaProvider cms={cms}>
+            <TinaMenuProvider menuId={routeMatch?.params.menuId || "Main"}>
                 <PostSelector />
                 <PageSelector />
                 <Switch>
@@ -62,8 +64,8 @@ const CMSProvider: React.FunctionComponent<{init: () => TinaCMS, children}> = (p
                         </ContentContext.Provider>
                     )} />
                 </Switch>
-            </TinaProvider>
-        </MenuContext.Provider>
+            </TinaMenuProvider>
+        </TinaProvider>
     );
 }
 
@@ -73,6 +75,7 @@ ReactDOM.render(
             init={() => cmsFromStores(
                 new LocalStorageStore<Post>("__posts"),
                 new LocalStorageStore<Post>("__pages"),
+                new LocalStorageStore<Menu>("__menu"),
                 new LocalStorageStore<Author>("__authors")
             )}
         >

--- a/src/modules/cms/hooks.ts
+++ b/src/modules/cms/hooks.ts
@@ -1,6 +1,13 @@
 import {useCMS} from "tinacms";
 
-import {DataStore, Post, Author} from "../datastore";
+import {
+    DataStore,
+    DataSearch,
+    Post,
+    Author,
+    Menu,
+    Entry,
+} from "../datastore";
 
 function assertApi<T>(id: string): T {
     const cms = useCMS();
@@ -19,4 +26,8 @@ export function usePages(): DataStore<Post> {
 
 export function useAuthors(): DataStore<Author> {
     return assertApi<DataStore<Author>>("author");
+}
+
+export function useMenus(): DataStore<Menu> & DataSearch<Entry & Menu> {
+    return assertApi<DataStore<Menu> & DataSearch<Entry & Menu>>("menu");
 }

--- a/src/modules/cms/utilities.ts
+++ b/src/modules/cms/utilities.ts
@@ -1,12 +1,17 @@
 import {TinaCMS} from "tinacms";
-import {postCreator} from "../plugins";
-import {DataStore, Author, Post} from "../datastore";
+import {postCreator, menuCreator} from "../plugins";
+import {DataStore, Author, Post, Menu, DataSearch} from "../datastore";
 
-export function cmsFromStores(postStore: DataStore<Post>, pageStore: DataStore<Post>, authorStore: DataStore<Author>): TinaCMS {
+export function cmsFromStores(
+    postStore: DataStore<Post>,
+    pageStore: DataStore<Post>,
+    menuStore: DataStore<Menu> & DataSearch<Menu>,
+    authorStore: DataStore<Author>,
+): TinaCMS {
     const cms = new TinaCMS();
     cms.plugins.add(
         postCreator({
-            name: "Add Basic Post",
+            name: "Add Post",
             onSubmit: (values) => {
                 return postStore.add({
                     title: values.title || "Untitled post",
@@ -18,12 +23,24 @@ export function cmsFromStores(postStore: DataStore<Post>, pageStore: DataStore<P
     );
     cms.plugins.add(
         postCreator({
-            name: "Add Special Post",
+            name: "Add Page",
             onSubmit: (values) => {
-                return postStore.add({
-                    title: values.title || "Untitled post",
+                return pageStore.add({
+                    title: values.title || "Untitled page",
                     type: "basic",
                     content: "",
+                });
+            }
+        })
+    );
+    cms.plugins.add(
+        menuCreator({
+            name: "Add Menu",
+            onSubmit: (values) => {
+                return menuStore.add({
+                    name: values.name || "Untitled menu",
+                    entries: [],
+                    tags: [],
                 });
             }
         })
@@ -32,5 +49,6 @@ export function cmsFromStores(postStore: DataStore<Post>, pageStore: DataStore<P
     cms.registerApi("authors", authorStore);
     cms.registerApi("posts", postStore);
     cms.registerApi("pages", pageStore);
+    cms.registerApi("menu", menuStore);
     return cms;
 }

--- a/src/modules/datastore/datasearch.ts
+++ b/src/modules/datastore/datasearch.ts
@@ -13,6 +13,7 @@ export interface AndQuery<Q extends BaseQuery<any>> extends BaseQuery<"and"> {
 export interface PropertyQuery<T = string> extends BaseQuery<"property"> {
     propertyId: T;
     criteria: string;
+    partial?: boolean;
 }
 
 export type SearchQuery<P = string> = (
@@ -25,12 +26,8 @@ export interface QueryDescriptor<T extends {type: any}> {
     type: T["type"],
 }
 
-export interface DataSearch<T, Q extends {type: any} = SearchQuery> {
+export interface DataSearch<T, Q extends {type: any} = SearchQuery<keyof T>> {
     search(query: Q): Promise<T[]>;
     first(query: Q): Promise<T>;
     availableQueries(): Promise<QueryDescriptor<Q>[]>;
-}
-
-export type Entry = {
-    id: string;
 }

--- a/src/modules/datastore/index.ts
+++ b/src/modules/datastore/index.ts
@@ -1,4 +1,5 @@
 export * from "./types";
 export * from "./datastore";
+export * from "./datasearch";
 export * from "./local-storage-datastore";
 export * as Utilities from "./utilities";

--- a/src/modules/datastore/local-storage-datastore.ts
+++ b/src/modules/datastore/local-storage-datastore.ts
@@ -39,7 +39,12 @@ export class LocalStorageStore<T> implements DataStore<T>, DataSearch<T, SearchQ
             case "and":
                 return query.queries.reduce((acc, q) => this._search(acc, q), entries);
             case "property":
-                return entries.filter(entry => String(entry[query.propertyId]).match(query.criteria));
+                return entries.filter(entry => query.partial ? (
+                        String(entry[query.propertyId]).match(query.criteria)
+                    ) : (
+                        String(entry[query.propertyId]) === query.criteria
+                    )
+                );
         }
     }
 

--- a/src/modules/datastore/types.ts
+++ b/src/modules/datastore/types.ts
@@ -11,3 +11,13 @@ export type Author = {
     name: string;
     index?: number;
 }
+
+export type MenuEntry = {
+    name: string;
+    link?: string;
+    entries: MenuEntry[];
+}
+
+export type Menu = MenuEntry & {
+    tags: string[];
+};

--- a/src/modules/plugins.ts
+++ b/src/modules/plugins.ts
@@ -1,5 +1,5 @@
 import {ContentCreatorPlugin} from "tinacms";
-import {Post} from "./datastore";
+import {Post, Menu} from "./datastore";
 
 export function postCreator({
     name,
@@ -15,6 +15,27 @@ export function postCreator({
             {
                 name: 'title',
                 label: 'Title',
+                component: 'text',
+            }
+        ],
+        onSubmit,
+    }
+}
+
+export function menuCreator({
+    name,
+    onSubmit,
+}: {
+    name: string,
+    onSubmit: (c: Pick<Menu, "name">) => Promise<any>;
+}): ContentCreatorPlugin<Pick<Menu, "name">> {
+    return {
+        name: name,
+        __type: "content-creator",
+        fields: [
+            {
+                name: 'name',
+                label: 'Name',
                 component: 'text',
             }
         ],


### PR DESCRIPTION
This branch adds initial editing for flat menus. While the menu data supports hierarchies the blog and the editor does not. This branch does the following:
* Add support for flat menus with simple links
* Improve property search query
* Enable triggering links in the blog UI
* Close #7 